### PR TITLE
comment arch-compute check and logging tflops

### DIFF
--- a/megatron/fused_kernels/__init__.py
+++ b/megatron/fused_kernels/__init__.py
@@ -3,7 +3,6 @@
 import os
 import pathlib
 import subprocess
-
 from torch.utils import cpp_extension
 
 # Setting this param to a list has a problem of generating different
@@ -23,9 +22,9 @@ def load(args):
     if int(bare_metal_major) >= 11:
         cc_flag.append('-gencode')
         cc_flag.append('arch=compute_80,code=sm_80')
-        if int(bare_metal_minor) >= 7:
-            cc_flag.append('-gencode')
-            cc_flag.append('arch=compute_90,code=sm_90')
+        # if int(bare_metal_minor) >= 7:
+        #     cc_flag.append('-gencode')
+        #     cc_flag.append('arch=compute_90,code=sm_90')
 
     # Build path
     srcpath = pathlib.Path(__file__).parent.absolute()

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -615,6 +615,33 @@ def training_log(loss_dict, total_loss_dict, learning_rate, iteration,
     if iteration % args.log_interval == 0:
         elapsed_time = timers('interval-time').elapsed(barrier=True)
         elapsed_time_per_iteration = elapsed_time / total_iterations
+        
+        # Not checking for variable sequence length to compute throughput 
+        seq_len = args.seq_length
+        hidden_size = args.hidden_size
+        num_layers = args.num_layers
+        vocab_size = args.padded_vocab_size
+    
+        samples_per_sec = batch_size / elapsed_time_per_iteration
+
+        # General TFLOPs formula (borrowed from Equation 3 in Section 5.1 of
+        # https://arxiv.org/pdf/2104.04473.pdf).
+        # The factor of 4 is when used with activation check-pointing,
+        # otherwise it will be 3
+        checkpoint_activations_factor = 4 if args.recompute_granularity else 3
+        
+        # GLU activations double the hidden states in the upscaling feed-forward in each transformer layer
+        # This leads to 16bsh^2 instead of 8bsh^2 per first feed-forward layer in MLP, thus we increase the coefficient by 8.
+        # Refer to https://github.com/bigscience-workshop/Megatron-DeepSpeed/pull/283#issue-1260805063 for more details.
+        
+        coefficient = 24
+                         
+        flops_per_iteration = (coefficient * checkpoint_activations_factor * batch_size * seq_len * num_layers * \
+                              (hidden_size ** 2)) * (1. + (seq_len / (6. * hidden_size)) + \
+                              (vocab_size / (16. * num_layers * hidden_size)))
+        tflops = flops_per_iteration / (elapsed_time_per_iteration * args.world_size * (10 ** 12))
+        
+        
         if writer:
             if args.log_timers_to_tensorboard:
                 writer.add_scalar('iteration-time',
@@ -623,8 +650,8 @@ def training_log(loss_dict, total_loss_dict, learning_rate, iteration,
             iteration, args.train_iters)
         log_string += ' consumed samples: {:12d} |'.format(
             args.consumed_train_samples)
-        log_string += ' elapsed time per iteration (ms): {:.1f} |'.format(
-            elapsed_time_per_iteration * 1000.0)
+        log_string += ' elapsed time per iteration (s): {:.1f} |'.format(
+            elapsed_time_per_iteration)
         log_string += ' learning rate: {:.3E} |'.format(learning_rate)
         log_string += ' global batch size: {:5d} |'.format(batch_size)
         for key in total_loss_dict:
@@ -646,6 +673,8 @@ def training_log(loss_dict, total_loss_dict, learning_rate, iteration,
             total_loss_dict[skipped_iters_key])
         log_string += ' number of nan iterations: {:3d} |'.format(
             total_loss_dict[nan_iters_key])
+        log_string += ' samples per second: {:.3f} |'.format(samples_per_sec)
+        log_string += ' TFLOPs: {:.2f} |'.format(tflops)
         total_loss_dict[advanced_iters_key] = 0
         total_loss_dict[skipped_iters_key] = 0
         total_loss_dict[nan_iters_key] = 0


### PR DESCRIPTION
This PR entails the following:
1. Comments out the check to add `arch=compute_90,code=sm_90` since it is not supported in JUWELS Booster 
```
nvcc fatal   : Unsupported gpu architecture 'compute_90'
[default0]:ninja: build stopped: subcommand failed.
[default0]:Traceback (most recent call last):
[default0]:  File "/p/software/juwelsbooster/stages/2023/software/PyTorch/1.12.0-foss-2022a-CUDA-11.7/lib/python3.10/site-packages/torch/utils/cpp_extension.py", line 1808, in _run_ninja_build
[default0]:    subprocess.run(
[default0]:  File "/p/software/juwelsbooster/stages/2023/software/Python/3.10.4-GCCcore-11.3.0/lib/python3.10/subprocess.py", line 524, in run
[default0]:    raise CalledProcessError(retcode, process.args,
[default0]:subprocess.CalledProcessError: Command '['ninja', '-v']' returned non-zero exit status 1.
```

2. Added logging of `elapsed time per iteration`, `samples per second` and `TFlops`  based on the implementation in [Megatron-Deepspeed](https://github.com/OpenGPTX/bigscience_megatron_deepspeed/blob/a280f7913a106193e4f556be1c647df5b65d1f2e/megatron/training.py#L684)