### PR TITLE
FlashAttention2 Implementation

### DIFF
--- a/megatron/model/transformer.py
+++ b/megatron/model/transformer.py
@@ -32,8 +32,10 @@ except ImportError:
 try:
     from flash_attn.flash_attn_interface import flash_attn_unpadded_func
 except ImportError:
-    flash_attn_unpadded_func = None
-
+    try:
+        from flash_attn.flash_attn_interface import flash_attn_varlen_func as flash_attn_unpadded_func
+    except ImportError:
+        flash_attn_unpadded_func = None
 
 """ We use the following notation throughout this file:
      h: hidden size


### PR DESCRIPTION
This PR 
- Implements `FlashAttention-2` when using the latest `flash-attn version >= 1.0.9` and `FlashAttention-1` for previous versions.
- Currently does not work with ALiBi positional embedding
- Works only with causal attention masking and self-attention



Example comparison for using FlashAttention with 6.7B model:
### FlashAttention-1
` iteration       10/  270843 | consumed samples:         2560 | consumed tokens:      5242880 | elapsed time per iteration (s): 28.52 | learning rate: 1.678E-06 | global batch size:   256 | lm loss: 1.819290E+01 | loss scale: 4096.0 | grad norm: 5.472 | num zeros: 0.0 | number of skipped iterations:   0 | number of nan iterations:   0 | samples per second: 8.975 | TFLOPs: 131.14 |`
### FlashAttention-2
`iteration       10/  270843 | consumed samples:         2560 | elapsed time per iteration (s): 18.8127 | learning rate: 1.678E-06 | global batch size:   256 | lm loss: 1.041547E+01 | loss scale: 4096.0 | grad norm: 0.006 | number of skipped iterations:   0 | number of nan iterations:   0 | samples per second: 13.608 | TFLOPs: 198.85 |`
