### PR TITLE
Indented torch.init_distributed()

### DIFF
--- a/megatron/initialize.py
+++ b/megatron/initialize.py
@@ -192,13 +192,13 @@ def _initialize_distributed():
             else:
                 args.local_rank = device
             torch.cuda.set_device(device)
-    # Call the init process
-    torch.distributed.init_process_group(
-        backend=args.distributed_backend,
-        world_size=args.world_size,
-        rank=args.rank,
-        timeout=timedelta(minutes=args.distributed_timeout_minutes),
-    )
+        # Call the init process
+        torch.distributed.init_process_group(
+            backend=args.distributed_backend,
+            world_size=args.world_size,
+            rank=args.rank,
+            timeout=timedelta(minutes=args.distributed_timeout_minutes),
+        )
 
     # Set the tensor model-parallel, pipeline model-parallel, and
     # data-parallel communicators.


### PR DESCRIPTION
Indented the init_ditributed in initialize.py, to the else path, such that it's only executed if torch distributed is really not initialized. 

It created issues whoithin the tracing setup, where we init the processgroup on our to be able to trace all GPUs correctly.
It then tried to init the processgroup twice and create the following error: RuntimeError: trying to initialize the default process group twice!